### PR TITLE
Check that user calling activate/deactivate is admin

### DIFF
--- a/arlas-iam-core/src/main/java/io/arlas/iam/core/AuthService.java
+++ b/arlas-iam-core/src/main/java/io/arlas/iam/core/AuthService.java
@@ -50,8 +50,8 @@ public interface AuthService {
     User updateUser(User user, String oldPassword, String newPassword, String firstName, String lastName, String locale, String timezone) throws NonMatchingPasswordException;
     void deleteUser(UUID actingId, UUID targetId) throws NotAllowedException;
 
-    Optional<User> activateUser(UUID userId);
-    Optional<User> deactivateUser(UUID userId) throws NotAllowedException;
+    Optional<User> activateUser(UUID actingId, UUID userId) throws NotAllowedException;
+    Optional<User> deactivateUser(UUID actingId, UUID userId) throws NotAllowedException;
 
     ApiKey createApiKey(User user, UUID ownerId, UUID oid, String name, int ttlInDays, Set<String> roleIds) throws NotAllowedException, NotFoundException;
     void deleteApiKey(User user, UUID ownerId, UUID oid, UUID apiKeyId) throws NotFoundException, NotAllowedException;

--- a/arlas-iam-core/src/main/java/io/arlas/iam/impl/HibernateAuthService.java
+++ b/arlas-iam-core/src/main/java/io/arlas/iam/impl/HibernateAuthService.java
@@ -450,7 +450,10 @@ public class HibernateAuthService implements AuthService {
     }
 
     @Override
-    public Optional<User> activateUser(UUID userId) {
+    public Optional<User> activateUser(UUID actingId, UUID userId) throws NotAllowedException {
+        if (!isAdmin(actingId)) {
+            throw new NotAllowedException("Admin only can deactivate a user.");
+        }
         Optional<User> user = readUser(userId);
         user.ifPresent(u -> {
             u.setActive(true);
@@ -460,7 +463,10 @@ public class HibernateAuthService implements AuthService {
     }
 
     @Override
-    public Optional<User> deactivateUser(UUID userId) throws NotAllowedException {
+    public Optional<User> deactivateUser(UUID actingId, UUID userId) throws NotAllowedException {
+        if (!isAdmin(actingId)) {
+            throw new NotAllowedException("Admin only can deactivate a user.");
+        }
         if (isAdmin(userId)) {
             throw new NotAllowedException("Admin cannot be deactivated.");
         }

--- a/arlas-iam-rest/src/main/java/io/arlas/iam/rest/service/IAMRestService.java
+++ b/arlas-iam-rest/src/main/java/io/arlas/iam/rest/service/IAMRestService.java
@@ -56,6 +56,8 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.*;
+import jakarta.ws.rs.core.Response.StatusType;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -267,7 +269,7 @@ public class IAMRestService {
             @CookieParam("refresh_token") Cookie refreshToken
     ) throws ArlasException {
         if (refreshToken == null) {
-            throw new InvalidTokenException("Missing refresh token in cookie");
+                return Response.status(401, "Missing refresh token in cookie").build();
         }
         RefreshTokenCookie rt = new RefreshTokenCookie(refreshToken.getValue());
         LoginSession loginSession = authService.refresh(rt.userId, rt.refreshToken, uriInfo.getBaseUri().getHost());

--- a/arlas-iam-rest/src/main/java/io/arlas/iam/rest/service/IAMRestService.java
+++ b/arlas-iam-rest/src/main/java/io/arlas/iam/rest/service/IAMRestService.java
@@ -570,8 +570,8 @@ public class IAMRestService {
 
             @Parameter(name = "id", required = true)
             @PathParam(value = "id") String id
-    ) {
-        authService.activateUser(UUID.fromString(id));
+            ) throws NotAllowedException, NotFoundException {
+                authService.activateUser(getUser(headers).getId(), UUID.fromString(id));
         logUAM(request, headers,  "users", "activate-user-account");
         return Response.accepted(uriInfo.getRequestUriBuilder().build())
                 .entity(new ArlasMessage("User activated."))
@@ -603,8 +603,8 @@ public class IAMRestService {
 
             @Parameter(name = "id", required = true)
             @PathParam(value = "id") String id
-    ) throws NotAllowedException {
-        authService.deactivateUser(UUID.fromString(id));
+    ) throws NotAllowedException, NotFoundException {
+        authService.deactivateUser(getUser(headers).getId(), UUID.fromString(id));
         logUAM(request, headers,  "users", "deactivate-user-account");
         return Response.accepted(uriInfo.getRequestUriBuilder().build())
                 .entity(new ArlasMessage("User deactivated."))

--- a/arlas-iam-tests/src/test/java/io/arlas/iam/test/AuthITUser.java
+++ b/arlas-iam-tests/src/test/java/io/arlas/iam/test/AuthITUser.java
@@ -527,6 +527,16 @@ public class AuthITUser extends AuthEndpoints {
     }
 
     @Test
+    public void test908DeactivateUser() {
+        deactivateUser(userId1, userId2).then().statusCode(greaterThan(299));
+    }
+
+    @Test
+    public void test908DeactivateUser() {
+        activateUser(userId1, userId2).then().statusCode(greaterThan(299));
+    }
+
+    @Test
     public void test903ActivateUser() {
         activateUser("admin", userId2).then().statusCode(202);
     }

--- a/arlas-iam-tests/src/test/java/io/arlas/iam/test/AuthITUser.java
+++ b/arlas-iam-tests/src/test/java/io/arlas/iam/test/AuthITUser.java
@@ -523,12 +523,12 @@ public class AuthITUser extends AuthEndpoints {
 
     @Test
     public void test902DeactivateUser() {
-        deactivateUser(userId1, userId2).then().statusCode(202);
+        deactivateUser("admin", userId2).then().statusCode(202);
     }
 
     @Test
     public void test903ActivateUser() {
-        activateUser(userId1, userId2).then().statusCode(202);
+        activateUser("admin", userId2).then().statusCode(202);
     }
 
     @Test

--- a/arlas-iam-tests/src/test/java/io/arlas/iam/test/AuthITUser.java
+++ b/arlas-iam-tests/src/test/java/io/arlas/iam/test/AuthITUser.java
@@ -532,7 +532,7 @@ public class AuthITUser extends AuthEndpoints {
     }
 
     @Test
-    public void test908DeactivateUser() {
+    public void test909ActivateUser() {
         activateUser(userId1, userId2).then().statusCode(greaterThan(299));
     }
 


### PR DESCRIPTION
The activate/deactivate must be called by admin only. This checks that the acting user is admin, raises NotAllowedException otherwise.
This addresses the backend aspect of [ARLAS-IAM: (De)activate should be done by admin only gisaia/ARLAS-wui-iam#112](https://github.com/gisaia/ARLAS-wui-iam/issues/112)

 - Fix gisaia/ARLAS-wui/issues/921

Side change:
- Fix #196 
